### PR TITLE
Include operators in mock definition.

### DIFF
--- a/src/operators.js
+++ b/src/operators.js
@@ -1,0 +1,90 @@
+
+'use strict';
+/**
+ * Operator symbols to be used when querying data
+ *
+ * @see {@link Model#where}
+ *
+ * @property eq
+ * @property ne
+ * @property gte
+ * @property gt
+ * @property lte
+ * @property lt
+ * @property not
+ * @property is
+ * @property in
+ * @property notIn
+ * @property like
+ * @property notLike
+ * @property iLike
+ * @property notILike
+ * @property startsWith
+ * @property endsWith
+ * @property substring
+ * @property regexp
+ * @property notRegexp
+ * @property iRegexp
+ * @property notIRegexp
+ * @property between
+ * @property notBetween
+ * @property overlap
+ * @property contains
+ * @property contained
+ * @property adjacent
+ * @property strictLeft
+ * @property strictRight
+ * @property noExtendRight
+ * @property noExtendLeft
+ * @property and
+ * @property or
+ * @property any
+ * @property all
+ * @property values
+ * @property col
+ * @property placeholder
+ * @property join
+ */
+const Op = {
+  eq: Symbol.for('eq'),
+  ne: Symbol.for('ne'),
+  gte: Symbol.for('gte'),
+  gt: Symbol.for('gt'),
+  lte: Symbol.for('lte'),
+  lt: Symbol.for('lt'),
+  not: Symbol.for('not'),
+  is: Symbol.for('is'),
+  in: Symbol.for('in'),
+  notIn: Symbol.for('notIn'),
+  like: Symbol.for('like'),
+  notLike: Symbol.for('notLike'),
+  iLike: Symbol.for('iLike'),
+  notILike: Symbol.for('notILike'),
+  startsWith: Symbol.for('startsWith'),
+  endsWith: Symbol.for('endsWith'),
+  substring: Symbol.for('substring'),
+  regexp: Symbol.for('regexp'),
+  notRegexp: Symbol.for('notRegexp'),
+  iRegexp: Symbol.for('iRegexp'),
+  notIRegexp: Symbol.for('notIRegexp'),
+  between: Symbol.for('between'),
+  notBetween: Symbol.for('notBetween'),
+  overlap: Symbol.for('overlap'),
+  contains: Symbol.for('contains'),
+  contained: Symbol.for('contained'),
+  adjacent: Symbol.for('adjacent'),
+  strictLeft: Symbol.for('strictLeft'),
+  strictRight: Symbol.for('strictRight'),
+  noExtendRight: Symbol.for('noExtendRight'),
+  noExtendLeft: Symbol.for('noExtendLeft'),
+  and: Symbol.for('and'),
+  or: Symbol.for('or'),
+  any: Symbol.for('any'),
+  all: Symbol.for('all'),
+  values: Symbol.for('values'),
+  col: Symbol.for('col'),
+  placeholder: Symbol.for('placeholder'),
+  join: Symbol.for('join')
+};
+
+module.exports = Op;

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -14,7 +14,8 @@ var path = require('path'),
 	Utils = require('./utils'),
 	Errors = require('./errors'),
 	DataTypes = require('./data-types')({}),
-	QueryInterface = require('./queryinterface');
+	QueryInterface = require('./queryinterface'),
+	Op = require('./operators');
 
 /**
  * Sequelize Mock Object. This can be initialize much the same way that Sequelize itself
@@ -409,5 +410,11 @@ Sequelize.prototype.literal = function (arg) {
 Sequelize.prototype.authenticate = async function() {
 	return;
 };
+
+/**
+ * Operators symbols to be used for querying data
+ * @see  {@link Operators}
+ */
+Sequelize.Op = Op;
 
 module.exports = Sequelize;


### PR DESCRIPTION
This is to add Op to the Sequelize mock such that we can do things such as the following:

Assuming
const { Op } = Sequelize;

MockModel.findOne({
      where: {
        objectId: {
          **[Op.eq]: objectId,**
        },
      },
    });

Without this you get errors such as `Cannot read property 'eq' of undefined`